### PR TITLE
fix: focus tapped window on touchscreen (HUM-165)

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1670,6 +1670,15 @@ impl State {
                     let under = State::surface_under(position, &output, &shell)
                         .map(|(target, pos)| (target, pos.as_logical()));
 
+                    // Determine which window/surface should receive keyboard focus.
+                    // `surface_under`/`touch.down` only route touch events to the
+                    // surface under the finger; they never change the keyboard focus
+                    // or raise/activate the tapped window. Without this, tapping a
+                    // window behind the currently focused one does nothing (HUM-165).
+                    // Mirror the pointer-button path, which calls `Shell::set_focus`.
+                    let keyboard_focus_target =
+                        State::element_under(position, &output, &shell, &seat);
+
                     // Check for layer surface dismiss on touch down (with whether the
                     // touch landed on layer-shell chrome, for opted-in controllers).
                     let clicked_surface_id = under
@@ -1708,6 +1717,16 @@ impl State {
 
                     let serial = SERIAL_COUNTER.next_serial();
                     let touch = seat.get_touch().unwrap();
+
+                    // Change keyboard focus to the tapped window, unless touch is
+                    // already grabbed (e.g. an in-progress client touch gesture),
+                    // in which case focus must stay with the grab owner.
+                    if !touch.is_grabbed()
+                        && let Some(target) = keyboard_focus_target
+                    {
+                        Shell::set_focus(self, Some(&target), &seat, Some(serial), false);
+                    }
+
                     touch.down(
                         self,
                         under,


### PR DESCRIPTION
## Summary

Fixes [HUM-165](https://playtron-one.atlassian.net/browse/HUM-165): tapping a window that sits behind the currently focused window via the touchscreen produced no result — the user could not shift focus by touch.

## Root cause

The `InputEvent::TouchDown` handler in `src/input/mod.rs` computes the surface under the finger and calls `touch.down()`, which only *routes* touch events to that surface. It never changed the **keyboard focus** or raised/activated the tapped window.

The pointer-button path already does this: on press it calls `Shell::set_focus(...)` for the element under the pointer. The touch path had no equivalent, so keyboard focus (and window activation/raise) stayed on the previously focused window.

## Change

In the touch-down path, mirror the pointer-button behavior:
- Compute the keyboard focus target with `State::element_under(...)` (same helper the pointer path uses).
- Call `Shell::set_focus(...)` for that target on touch down.
- Guard it with `!touch.is_grabbed()`, so an in-progress client touch gesture (a grab) keeps focus with the grab owner — matching how the pointer path guards on `!pointer.is_grabbed()`.

Focus is only changed when a real element is under the finger; tapping empty desktop leaves focus unchanged (same as the pointer path).

## Verification

- `cargo check`, `cargo clippy`, and `cargo fmt --check` all clean.
- `cargo test` passes (21 passed, 0 failed).
- The fix is a minimal, type-checked mirror of the established pointer-button focus path.

Full behavioral verification (tapping a window behind the focused one on the Qualcomm CRD touchscreen and confirming focus shifts) requires touchscreen hardware and a running compositor session, which cannot be exercised in CI/headless. It should be smoke-tested on-device per the ticket's reproduction steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HUM-165]: https://playtron-one.atlassian.net/browse/HUM-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ