### PR TITLE
fix: hide cursor on touchscreen input (HUM-166)

### DIFF
--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -408,7 +408,10 @@ pub fn notify_cursor_activity(state: &State, seat: &Seat<State>) -> bool {
     was_hidden
 }
 
-fn hide_cursor(state: &mut State, seat: &Seat<State>) {
+/// Hide the cursor and cancel any pending idle-hide timer. No-op while the
+/// pointer is grabbed (e.g. an in-progress drag). The cursor is revealed again
+/// by [`notify_cursor_activity`] on the next real pointer/mouse activity.
+pub fn hide_cursor(state: &mut State, seat: &Seat<State>) {
     if let Some(ptr) = seat.get_pointer()
         && ptr.is_grabbed()
     {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    backend::render::{ElementFilter, cursor::notify_cursor_activity},
+    backend::render::{
+        ElementFilter,
+        cursor::{hide_cursor, notify_cursor_activity},
+    },
     config::{
         Action, Config, PrivateAction,
         key_bindings::{
@@ -1716,6 +1719,12 @@ impl State {
                     }
 
                     let serial = SERIAL_COUNTER.next_serial();
+
+                    // Hide the mouse cursor while interacting via touch (as Windows
+                    // does). It stays hidden until the next real pointer/mouse activity,
+                    // which reveals it again via `notify_cursor_activity`.
+                    hide_cursor(self, &seat);
+
                     let touch = seat.get_touch().unwrap();
 
                     // Change keyboard focus to the tapped window, unless touch is


### PR DESCRIPTION
## Summary

Addresses [HUM-166](https://playtron-one.atlassian.net/browse/HUM-166): the mouse cursor stayed visible and stationary while interacting via the touchscreen, which looks broken.

Rather than moving the cursor to the touch point (the ticket's literal ask, which conflates two different input models), this matches the **Windows behaviour**: hide the pointer cursor as soon as touch input starts, and let it reappear on the next real mouse movement.

## Changes

- `src/input/mod.rs` — `TouchDown` now calls `hide_cursor(self, &seat)`, hiding the cursor when a touch interaction begins.
- `src/backend/render/cursor.rs` — `hide_cursor` is made `pub` (with a doc comment) so the input handler can call it.

The cursor reappears automatically: the existing pointer paths already call `notify_cursor_activity` on mouse motion / buttons / axis, which clears the `hidden` flag and re-renders the cursor. So moving a physical mouse brings it back.

`hide_cursor` is a no-op while the pointer is grabbed (e.g. an in-progress drag), so it won't disrupt active pointer interactions.

## Verification

- `cargo build` — succeeds.
- **Needs on-device QA** with a touchscreen: confirm the cursor disappears on touch and reappears when a physical mouse is moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HUM-166]: https://playtron-one.atlassian.net/browse/HUM-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ