### PR TITLE
fix: honor keyboard-shortcuts inhibitor for Super-key voice/chat (HUM-370)

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2124,7 +2124,14 @@ impl State {
         // Ctrl+Alt+Super+Shift+F1x must not also trigger voice. (The activation
         // hold-timer below has the same guard, to cover any key-press order.)
         let perf_chord_mods = modifiers.ctrl && modifiers.alt && modifiers.shift;
-        if voice_config.enabled && !perf_chord_mods && (matches || is_f18 || is_voice_key_release) {
+        // Skip voice/chat handling while a keyboard-shortcuts inhibitor is active,
+        // so the Super press is forwarded to the focused client instead. Mirrors the
+        // `!shortcuts_inhibited` gate on global compositor shortcuts below.
+        if voice_config.enabled
+            && !perf_chord_mods
+            && !shortcuts_inhibited
+            && (matches || is_f18 || is_voice_key_release)
+        {
             // Block voice key handling entirely during session lock (idle/login screen)
             if shell.session_lock.is_some() {
                 tracing::debug!("Voice key ignored - session is locked");


### PR DESCRIPTION
## Summary

Fixes [HUM-370](https://playtron-one.atlassian.net/browse/HUM-370): *Pressing the Super Key summons an open Chat window in all circumstances.*

When a Chat window is open, pressing the Super key would immediately summon/focus it (or start voice input) **even while a keyboard-shortcuts inhibitor was active** for the focused surface. That made it impossible to assign Super-based shortcuts and interfered with other explicit Super-key functions.

## Root cause

In the keyboard filter (`src/input/mod.rs`), `shortcuts_inhibited` is already computed for the focused surface and gates the global compositor-shortcuts loop. But the voice/chat handling block (tap → focus chat input, hold → push-to-talk) ran **before** and never consulted it. The only early-out there was the session-lock check.

## Change

Gate the voice/chat block on `!shortcuts_inhibited`, mirroring the existing `!shortcuts_inhibited` gate on global shortcuts. When an inhibitor is active, the Super press now falls through and is forwarded to the focused client (the app capturing the key combo) instead of being intercepted for voice/chat.

## Verification

- `cargo check` passes.
- `cargo fmt --check` clean on the changed file.

Manual on-device QA recommended (open a Chat window, go to Settings → Shortcuts, record a Super-based shortcut, confirm the Chat window is no longer summoned), since compositor input behavior can't be exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HUM-370]: https://playtron-one.atlassian.net/browse/HUM-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ