### PR TITLE
fix: restore resizing after dragging a maximized window away to unmaximize (HUM-238)

### DIFF
--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -1308,6 +1308,19 @@ impl Drop for MoveGrab {
                         .unwrap_or(window_location);
                     shell.remap_x11_transient_children(remap_pos, &tc);
 
+                    // If the window was unmaximized during the drag, send a fresh
+                    // configure now that it is stably mapped at its drop location.
+                    // The unmaximize configure was emitted earlier while the element
+                    // was being torn down for the grab; a client that draws its own
+                    // decorations may not re-enable its resize handles until it sees
+                    // the settled, non-maximized state. This mirrors the button
+                    // restore path users rely on to recover resizing.
+                    if grab_state.target_size.is_some()
+                        && let Some((window, _)) = drop_result.as_ref()
+                    {
+                        window.force_configure();
+                    }
+
                     drop_result
                 } else {
                     let mut shell = state.common.shell.write();

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -7753,33 +7753,35 @@ impl Shell {
                 let elem_geo = element_geo.or_else(|| workspace.element_geometry(&old_mapped))?;
                 let mut initial_window_location = elem_geo.loc.to_global(workspace.output());
 
-                let mut new_size = if old_mapped.maximized_state.lock().unwrap().is_some() {
-                    // If surface is maximized then unmaximize it
-                    let geo = workspace.unmaximize_request(&old_mapped);
-                    // The pipelined unmaximize defers set_maximized/set_tiled
-                    // until animation completion, but the element is about to be
-                    // unmapped for the grab so the animation will never finish.
-                    // Clear the protocol state flags and configure to the target
-                    // (original) size immediately.
+                let mut new_size = if let Some(max_state) =
+                    old_mapped.maximized_state.lock().unwrap().take()
+                {
+                    // Unmaximize directly instead of going through the pipelined
+                    // `unmaximize_request`. The element is about to be unmapped for
+                    // the grab, so the deferred animation would never complete;
+                    // worse, that path emits a configure that re-asserts the
+                    // maximized state right before we clear it. A client-decorated
+                    // window that sees maximized re-asserted keeps its resize
+                    // handles hidden, so pulling it away from the top left it
+                    // unresizable. Clear the flags and configure to the restore
+                    // geometry in one clean step, mirroring the sticky branch below.
                     old_mapped.set_maximized(false);
                     old_mapped.set_tiled(false);
 
-                    // If the original geometry is as large as (or larger than)
-                    // the output zone, shrink to 2/3 so the window actually
-                    // appears unmaximized when dropped.
+                    // If the restore geometry is as large as (or larger than) the
+                    // output zone, shrink to 2/3 so the window actually appears
+                    // unmaximized when dropped.
                     let zone = layer_map_for_output(workspace.output()).non_exclusive_zone();
-                    let clamped_geo = geo.map(|mut g| {
-                        if let Some(s) = Self::drag_shrink_size(g.size.w, g.size.h, zone) {
-                            g.size = s.as_local();
-                        }
-                        g
-                    });
-
-                    if let Some(ref geo) = clamped_geo {
-                        old_mapped.set_geometry(geo.to_global(workspace.output()));
+                    let mut restore_geo = max_state.original_geometry;
+                    if let Some(s) =
+                        Self::drag_shrink_size(restore_geo.size.w, restore_geo.size.h, zone)
+                    {
+                        restore_geo.size = s.as_local();
                     }
+
+                    old_mapped.set_geometry(restore_geo.to_global(workspace.output()));
                     old_mapped.configure();
-                    clamped_geo.map(|geo| geo.size.as_logical())
+                    Some(restore_geo.size.as_logical())
                 } else {
                     // Not maximized, but if the window fills the output zone,
                     // shrink it on drag so the user can reposition it.


### PR DESCRIPTION
## Problem (HUM-238)

Maximize a window, then **pull it away from the top of the screen** to restore it. Afterward, moving the cursor over the window edges never shows the resize affordance — the window can't be resized. Restoring instead via the **titlebar restore button** works, and re-maximizing + button-restoring recovers the ability to resize.

## Root cause

Non-stacked toplevels are **client-side decorated** — the decoration handler (`src/wayland/handlers/decoration.rs`) requests `ClientSide` for them, so the client draws its own resize handles and keys their visibility off the maximized/tiled state the compositor sends via `xdg_toplevel` configures.

The drag-to-unmaximize path in `Shell::move_request` called the pipelined `unmaximize_request` purely to obtain the restore geometry. That path:

1. **Defers** clearing the maximized/tiled flags to an animation that never completes here — the element is immediately unmapped for the move grab, so the animation is dropped.
2. Along the way, **emits a configure that re-asserts `maximized`** (at a sub-zone size) right before the flags are cleared. A client that sees maximized re-asserted keeps its resize handles hidden. This configure is only emitted when the restore size is well below the output zone, which matches the intermittent reports (CNR vs. reproduced).
3. Sends the clean, non-maximized configure only **while the element is being torn down** for the grab — never once the window is stably settled at its drop location. The working button-restore path, by contrast, sends its final non-maximized configure at a stable settle.

## Changes

- **`src/shell/mod.rs` (`move_request`)** — unmaximize directly by taking `maximized_state` (the same pattern the sibling sticky-window branch already uses) instead of routing through the pipelined path. No contradictory maximized configure is emitted and no animation is orphaned; behaviour (restore geometry, 2/3 shrink, flag clearing) is otherwise identical.
- **`src/shell/grabs/moving.rs` (`MoveGrab` drop)** — once a window that was unmaximized during the drag is stably mapped at its drop location, send a fresh configure so client-drawn decorations re-sync to the settled non-maximized state. This mirrors the button-restore path users currently rely on to recover resizing. Gated on `target_size.is_some()`, so ordinary window moves are unaffected.

## Verification

- `cargo build` — clean
- `cargo clippy` — clean

⚠️ The interactive drag-then-resize behaviour could **not** be verified autonomously: it requires a GUI session and a real pointer drag, and no input-injection tooling is available here that wouldn't disturb the live compositor session. **Manual QA is needed** to confirm the end-to-end fix:

1. Maximize a client-decorated window (e.g. the Mail app, `gtk3-widget-factory`, or `cosmic-term`).
2. Drag its titlebar away from the top of the screen to restore it.
3. Move the cursor to the window edges and confirm the resize affordance appears and resizing works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)