### PR TITLE
fix(dnd): clear the drag icon when a drag is cancelled

### DIFF
--- a/src/wayland/handlers/data_device.rs
+++ b/src/wayland/handlers/data_device.rs
@@ -123,9 +123,32 @@ impl DndGrabHandler for State {
         seat: Seat<Self>,
         _location: Point<f64, Logical>,
     ) {
-        if let Some(icon) = seat.user_data().get::<Mutex<Option<DnDIcon>>>() {
-            icon.lock().unwrap().take();
+        clear_dnd_icon(&seat);
+    }
+
+    fn cancelled(&mut self, seat: Seat<Self>, _location: Point<f64, Logical>) {
+        // A cancelled grab (e.g. the source destroying its data source) never drops, so this is
+        // the only chance to drop the icon. Clients commonly keep the icon surface alive for the
+        // next drag, so relying on it dying would leave it painted on the cursor.
+        clear_dnd_icon(&seat);
+
+        // Unlike a drop, a cancel isn't driven by input, so nothing else damages the cursor plane.
+        let outputs = self
+            .common
+            .shell
+            .read()
+            .outputs()
+            .cloned()
+            .collect::<Vec<_>>();
+        for output in outputs {
+            self.backend.schedule_render(&output);
         }
+    }
+}
+
+fn clear_dnd_icon(seat: &Seat<State>) {
+    if let Some(icon) = seat.user_data().get::<Mutex<Option<DnDIcon>>>() {
+        icon.lock().unwrap().take();
     }
 }
 


### PR DESCRIPTION
Pressing Escape during a drag unsets the pointer grab, which sends smithay's DnDGrab down its cancel() path rather than drop(). We only implemented DndGrabHandler::dropped(), so cancelled() stayed the no-op default and the DnDIcon was left in the seat's user data — draw_dnd_icon kept painting it on the cursor until the client happened to destroy that surface, typically only after a later drag replaced it.

Clear the icon from both handlers, and schedule a render on cancel: a drop rides on the button release that damages the frame anyway, but a cancel can land with the pointer stationary.
